### PR TITLE
add runOnly option to test framework

### DIFF
--- a/PETestFramework/src/main/java/org/genevaers/testframework/TestDriver.java
+++ b/PETestFramework/src/main/java/org/genevaers/testframework/TestDriver.java
@@ -669,47 +669,50 @@ public class TestDriver {
 			}
 		}
 
-		test.verifyExpected();
+		if(test.getRunOnly().equals("Y")) {
+			System.out.println(Menu.PURPLE + "Run Only " + test.getName() + Menu.RESET);
+		} else {
+			test.verifyExpected();
 
 
-		// Messed up world of paths
-		// let's make them once somewhere and keep them around
+			// Messed up world of paths
+			// let's make them once somewhere and keep them around
 
-		// the testOutputPath
-		// the testBasePath
-		// And the story is a little messed up with extract or format file too
-		// Needs different prefix but we should be able to just say getOuptutFileName()
-		// and it sorts the type etc internally?
+			// the testOutputPath
+			// the testBasePath
+			// And the story is a little messed up with extract or format file too
+			// Needs different prefix but we should be able to just say getOuptutFileName()
+			// and it sorts the type etc internally?
 
-		// Not sure we need the TestResult types either?
+			// Not sure we need the TestResult types either?
 
-			Map<String, Object> nodeMap = new HashMap<>();
-			nodeMap.put("specName", test.getSpecPath());
-			nodeMap.put("testName", test.getName());
+				Map<String, Object> nodeMap = new HashMap<>();
+				nodeMap.put("specName", test.getSpecPath());
+				nodeMap.put("testName", test.getName());
 
-			try {
-				Template template = cfg.getTemplate("test/result.ftl");
-				Path resultFilePath;
-				Path resultPath = outPath.resolve(test.getFullName());
-				resultPath.toFile().mkdirs();
-				if (test.getResult().getMessage().startsWith("pass")) {
-					nodeMap.put("result", "SUCCESS");
-					logger.atInfo().log(Menu.GREEN + test.getResult().getMessage() + Menu.RESET);
-					resultFilePath = resultPath.resolve("pass.html");
-				} else {
-					nodeMap.put("result", "FAILCOMPARE");
-					logger.atSevere().log(Menu.RED + test.getResult().getMessage() + Menu.RESET);
-					resultFilePath = resultPath.resolve("fail.html");
+				try {
+					Template template = cfg.getTemplate("test/result.ftl");
+					Path resultFilePath;
+					Path resultPath = outPath.resolve(test.getFullName());
+					resultPath.toFile().mkdirs();
+					if (test.getResult().getMessage().startsWith("pass")) {
+						nodeMap.put("result", "SUCCESS");
+						logger.atInfo().log(Menu.GREEN + test.getResult().getMessage() + Menu.RESET);
+						resultFilePath = resultPath.resolve("pass.html");
+					} else {
+						nodeMap.put("result", "FAILCOMPARE");
+						logger.atSevere().log(Menu.RED + test.getResult().getMessage() + Menu.RESET);
+						resultFilePath = resultPath.resolve("fail.html");
+					}
+					nodeMap.put("outFiles", test.getFormatfiles());
+					Path cssPath = resultFilePath.relativize(outPath).resolve("w3.css");
+					nodeMap.put("cssPath", cssPath);
+					TemplateApplier.generateTestTemplatedOutput(template, nodeMap, resultFilePath);
+				} catch (IOException | TemplateException e) {
+					// TODO Auto-generated catch block
+					e.printStackTrace();
 				}
-				nodeMap.put("outFiles", test.getFormatfiles());
-				Path cssPath = resultFilePath.relativize(outPath).resolve("w3.css");
-				nodeMap.put("cssPath", cssPath);
-				TemplateApplier.generateTestTemplatedOutput(template, nodeMap, resultFilePath);
-			} catch (IOException | TemplateException e) {
-				// TODO Auto-generated catch block
-				e.printStackTrace();
-			}
-			// checkSetResultState(result);
+		}
 	}
 
 	public static boolean compareOutFiles(Path baseFolder, GersTest test, Path outPath) {

--- a/PETestFramework/src/main/java/org/genevaers/testframework/yamlreader/GersTest.java
+++ b/PETestFramework/src/main/java/org/genevaers/testframework/yamlreader/GersTest.java
@@ -57,6 +57,7 @@ public class GersTest {
     private OutputFile mr91out;
     private Spec spec;
     private Map<Integer, Boolean> viewResults = new TreeMap<>();
+    private String runOnly = "N";
 
     public String getName() {
         return name;
@@ -390,5 +391,13 @@ public class GersTest {
         } else {
             return extractfiles.stream().filter(f -> f.getDdname().equalsIgnoreCase(name)).findAny().orElse(null);
         }
+    }
+
+    public String getRunOnly() {
+        return runOnly;
+    }
+
+    public void setRunOnly(String runOnly) {
+        this.runOnly = runOnly;
     }
 }


### PR DESCRIPTION
Hi Gill,
can you add a runOnly: "Y" to tests you choose. As per the example below.

```
- name: "ALIGN"
  header: "ALIGN"
  description: "Align left, right, and centre"
  source: "WBXML"
  runOnly: "Y"
  xmlfiles:
  - name: "AlignText[9832].xml"

  eventfiles:
  - ddname: "ALIGN"
    filename: "ALIGN.TEXT"
  extractfiles:
  - ddname: "F0009832"
    space: "TRK"
    primary: "1"
    secondary: "1"
    recfm: "VB"
    lrecl: "300"

```
And veryify it works as desired.
You should then get an output like (with colours that don't show here)

```Choose an option:
5
[INFO] Running test 'ALIGN'
[INFO] Copy the XML to GEBT.ETEST.BIGASS.ALIGN.MR91.XMLS
[INFO] Copy the config files to GEBT.ETEST.BIGASS.ALIGN.PARM
[INFO] Copy the JCL files to GEBT.ETEST.BIGASS.ALIGN.JCL
[INFO] purged 3 jobs for ALIGN
[INFO] Expecting 3 completed jobs for ALIGN within 12 seconds
[INFO] (2) 1 completed jobs for ALIGN
[INFO] (3) 3 completed jobs for ALIGN
Run Only ALIGN
Enter Enter to continue
```
