### PR TITLE
Add Smoke Test spec list

### DIFF
--- a/PETestFramework/SmokeTest.yaml
+++ b/PETestFramework/SmokeTest.yaml
@@ -1,0 +1,5 @@
+specFileSets:
+  - name: "Regression Tests"
+    templateSetName: "gvbrcgtoPE.yaml"
+    specs:
+      - "PeTests/Arithmetic/BIGART.yaml" 


### PR DESCRIPTION
This new test spec list contains only one test spec.  This will be useful for testing the PE build process, where we don't need to execute a lot of tests and we want the job stream to finish quickly.  