### PR TITLE
Remove DB2 dependencies from pom.xml to fix build issues

### DIFF
--- a/GenevaIO/pom.xml
+++ b/GenevaIO/pom.xml
@@ -98,21 +98,6 @@ under the License.
 			<groupId>org.freemarker</groupId>
 			<artifactId>freemarker</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>com.ibm</groupId>
-			<artifactId>db2jcc_license_cu</artifactId>
-			<version>4</version>
-		</dependency>
-		<dependency>
-			<groupId>com.ibm</groupId>
-			<artifactId>db2jcc4</artifactId>
-			<version>4</version>
-		</dependency>
-		<dependency>
-			<groupId>com.ibm</groupId>
-			<artifactId>db2jcc_license_cisuz</artifactId>
-			<version>4</version>
-		</dependency>
 </dependencies>
 
 	<build>


### PR DESCRIPTION
### **Description**
This PR addresses an issue where the presence of DB2 dependencies in the [GenevaIO/pom.xml file](https://github.com/genevaers/Run-Control-Apps/blob/main/GenevaIO/pom.xml) caused the build to fail when using PostgreSQL in [genevaers/Workbench](https://github.com/genevaers/Workbench). The DB2 dependencies were checked in as part of a developer version and are not needed anymore.

### **Changes Made**
Removed the DB2 dependencies from GenevaIO/pom.xml:
### **Testing Performed**
Verified the build script works successfully after removing the DB2 dependencies.
### **Issue Reference**
This PR addresses fixes issue [Build Failure Due to DB2 Dependencies While Using PostgreSQL #173](https://github.com/genevaers/Workbench/issues/173) as per the [request](https://github.com/genevaers/Workbench/issues/173#issuecomment-2574338813) of maintainer [Kip Twitchell](https://github.com/KipTwitchell)

Tags: @KipTwitchell 